### PR TITLE
WB-140 Fix avgspeed and maxspeed on session

### DIFF
--- a/src/fitparser.cc
+++ b/src/fitparser.cc
@@ -393,8 +393,8 @@ void FitParser::Encode(const v8::FunctionCallbackInfo<v8::Value> &args)
 
     sessionMsg.SetEvent(FIT_EVENT_ACTIVITY);
     // todo: set avg speed, max speed, calories and other summary values
-    sessionMsg.SetAvgSpeed(GET_SINT("avgSpeed"));
-    sessionMsg.SetMaxSpeed(GET_SINT("maxSpeed"));
+    sessionMsg.SetAvgSpeed(GET_SNUM("avgSpeed"));
+    sessionMsg.SetMaxSpeed(GET_SNUM("maxSpeed"));
     // todo: add laps to session. Add them when target power goes from rest to active or vise versa
 
     Local<Array> jsonLaps = Local<Array>::Cast(inputSession->Get(String::NewFromUtf8(isolate, "laps")));


### PR DESCRIPTION
#### What’s this PR do?
Fix the average speed and max speed values on sessions object, they were using int value and now they use float values.
#### Any background context you want to provide?
- This update change the json structure base on the data available in SufferFestWeb
- The activity-from-data.js was generated with data from a real activity by SufferFestWeb
- Put decimal values con the average speed and max speed properties on json object
#### How should this be manually tested?

1. `npm install`
2. `npm test`
3. It should pass the test
4. Go to examples\content-to-js
5. `npm install`
6. `node index.js`
7. Verify that a file called temp.fit
8. Open the fit file in a desktop application like Golden Cheetah and review the content. (This file is created from NodeJS)
9. decode the file using fitSDK library and checn that average speedn and max speed have decimal on sessions record

#### Could any automated tests be added for this?
No
#### What are the relevant JIRA issues?
https://thesufferfest.atlassian.net/browse/WB-140
#### Screenshots (if appropriate)
