### PR TITLE
revert manufacturer ID back to SUF

### DIFF
--- a/src/fitparser.cc
+++ b/src/fitparser.cc
@@ -317,7 +317,7 @@ void FitParser::Encode(const v8::FunctionCallbackInfo<v8::Value> &args)
   // FileIdMesg SECTION
   fit::FileIdMesg fileIdMesg; // Every FIT file requires a File ID message
   fileIdMesg.SetType(FIT_FILE_ACTIVITY);
-  fileIdMesg.SetManufacturer(FIT_MANUFACTURER_WAHOO_FITNESS);
+  fileIdMesg.SetManufacturer(FIT_MANUFACTURER_THE_SUFFERFEST);
   fileIdMesg.SetProduct(1231);
   fileIdMesg.SetSerialNumber(12345);
   fileIdMesg.SetTimeCreated(GET_INT("timeCreated"));


### PR DESCRIPTION
This is to fix the issue where Garmin doesn't count activities with the Wahoo manufacturer ID toward your training load. 